### PR TITLE
Allow selector to be used to specify font

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ I've attempted to keep the API as close as possible to that of A-Frame's default
 | depthOffset           | depth-offset           | Depth buffer offset to help prevent z-fighting. Negative numbers are closer to camera, positives further.   | 0                               |
 | direction             | direction              | Main bidi direction of the text: 'auto', 'ltr', or 'rtl'                                                    | 'auto'                          |
 | fillOpacity           | fill-opacity           | Opacity of the glyph's fill.                                                                                | 1                               |
-| font                  | font                   | URL to a font file - can be a .ttf, .otf, or .woff (no .woff2)                                              | Roboto loaded from Google Fonts |
+| font                  | font                   | URL to a font file - can be a .ttf, .otf, or .woff (no .woff2) or an `<a-asset-item>` id such as `#font`.   | Roboto loaded from Google Fonts |
 | fontSize              | font-size              | Em-height at which to render the font, in meters.                                                           | 0.2                             |
 | letterSpacing         | letter-spacing         | Letter spacing in meters.                                                                                   | 0                               |
 | lineHeight            | line-height            | Line height as a multiple of the fontSize.                                                                  | *derived from font metrics*     |

--- a/src/aframe-troika-text-component.js
+++ b/src/aframe-troika-text-component.js
@@ -104,12 +104,19 @@ aframe.registerComponent(COMPONENT_NAME, {
     var data = this.data
     var mesh = this.troikaTextMesh
     var entity = this.troikaTextEntity
+    var font = data.font
 
     // Update the text mesh
     mesh.text = (data.value || '')
       .replace(/\\n/g, '\n')
       .replace(/\\t/g, '\t')
     mesh.textAlign = data.align
+
+    // Retrieve font path if preloaded in <a-assets> with unique id
+    if (data.font.startsWith('#')) {
+      const assetItem = document.querySelector(data.font);
+      font = assetItem.getAttribute('src');
+    }
 
     mesh.anchorX = anchorMapping[data.anchor === 'align' ? data.align : data.anchor] || 'center'
     mesh.anchorY = baselineMapping[data.baseline] || 'middle'
@@ -119,7 +126,7 @@ aframe.registerComponent(COMPONENT_NAME, {
     mesh.depthOffset = data.depthOffset || 0
     mesh.direction = data.direction
     mesh.fillOpacity = data.fillOpacity
-    mesh.font = data.font //TODO allow aframe stock font names
+    mesh.font = font //TODO allow aframe stock font names
     mesh.fontSize = data.fontSize
     mesh.letterSpacing = data.letterSpacing || 0
     mesh.lineHeight = data.lineHeight || 'normal'


### PR DESCRIPTION
This is a simple addition that lets you use a selector in place of the full font path. It partially addresses #19, but it doesn't do preloading with `preloadfont()` as I was unsure what values for characters and SDF glyph size would be appropriate.