### PR TITLE
Expose the unicodeFontsUrl property of Troika Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ I've attempted to keep the API as close as possible to that of A-Frame's default
 | strokeOpacity         | stroke-opacity         | Opacity of the stroke, from 0 to 1.                                                                         | 1                               |
 | strokeWidth           | stroke-width           | Width of a stroke drawn inside the glyph paths, as a number in meters or a percentage of the font-size.     | 0                               |
 | textIndent            | text-indent            | Width of an indentation space to be added before the first character of a line.                             | 0                               |
+| unicodeFontsURL       | unicode-fonts-url      | Location of [self-hosted font files](https://github.com/lojjic/unicode-font-resolver/blob/1.x/packages/data/README.md#self-hosting). | ''     |
 | whiteSpace            | white-space            | How whitespace should be handled (i.e., normal, nowrap).                                                    | normal (behaves like pre-wrap)  |
 
 Note: It does not currently follow how the built-in `text` component interacts with a `geometry` component for auto-sizing and anchoring. I think that's a nice feature so it's probably worth adding; in the meantime just use the `maxWidth` and `anchor`/`baseline` attributes to control it manually.

--- a/src/aframe-troika-text-component.js
+++ b/src/aframe-troika-text-component.js
@@ -73,6 +73,7 @@ aframe.registerComponent(COMPONENT_NAME, {
     strokeOpacity: {type: 'number', default: 1},
     strokeWidth: numberOrPercent(0),
     textIndent: {type: 'number', default: 0},
+    unicodeFontsURL: {type: 'string', default: ''},
     value: {type: 'string'},
     whiteSpace: {default: 'normal', oneOf: ['normal', 'nowrap']}
 
@@ -150,6 +151,7 @@ aframe.registerComponent(COMPONENT_NAME, {
     mesh.strokeOpacity = data.strokeOpacity
     mesh.strokeWidth = data.strokeWidth
     mesh.textIndent = data.textIndent
+    mesh.unicodeFontsURL = data.unicodeFontsURL
     mesh.whiteSpace = data.whiteSpace
     mesh.maxWidth = data.maxWidth
     mesh.sync()


### PR DESCRIPTION
This allows self-hosting of the data files from unicode-fonts-resolver.

Edit: I'm not sure  whether or not this is the best approach, but it looks like the minimum effort required to support self-hosting of the fonts.