### PR TITLE
Fix the clipRect parsing in A-Frame 1.6 and above

### DIFF
--- a/src/aframe-troika-text-component.js
+++ b/src/aframe-troika-text-component.js
@@ -29,6 +29,9 @@ aframe.registerComponent(COMPONENT_NAME, {
       type: 'string',
       default: '',
       parse: function(value) {
+        if (Array.isArray(value)) {
+          return value;
+        }
         if (value) {
           value = value.split(/[\s,]+/).reduce(function(out, val) {
             val = +val


### PR DESCRIPTION
This PR in A-Frame https://github.com/aframevr/aframe/pull/5474 introduces breaking changes for custom parsers, which affects the clipRect property. Basically the parse() function gets called with the previously-parsed value, which is an array and no longer has a "split" method, which leads to an exception. The simple fix here is to check for the special case upfront and just return the value, if it's the already parsed value. This fixes the compatibility with A-Frame 1.6 and beyond.